### PR TITLE
Submit open then submit rest of the ops

### DIFF
--- a/benches/io_uring_local.rs
+++ b/benches/io_uring_local.rs
@@ -51,7 +51,7 @@ async fn load_files_with_local_file_system(
 }
 
 fn bench(c: &mut Criterion) {
-    const N_FILES: usize = 14;
+    const N_FILES: usize = 16;
 
     // Configure group:
     let mut group = c.benchmark_group(format!("load_{N_FILES}_files"));

--- a/benches/io_uring_local.rs
+++ b/benches/io_uring_local.rs
@@ -51,7 +51,7 @@ async fn load_files_with_local_file_system(
 }
 
 fn bench(c: &mut Criterion) {
-    const N_FILES: usize = 13;
+    const N_FILES: usize = 14;
 
     // Configure group:
     let mut group = c.benchmark_group(format!("load_{N_FILES}_files"));

--- a/benches/io_uring_local.rs
+++ b/benches/io_uring_local.rs
@@ -51,7 +51,7 @@ async fn load_files_with_local_file_system(
 }
 
 fn bench(c: &mut Criterion) {
-    const N_FILES: usize = 16;
+    const N_FILES: usize = 13;
 
     // Configure group:
     let mut group = c.benchmark_group(format!("load_{N_FILES}_files"));

--- a/src/io_uring_local.rs
+++ b/src/io_uring_local.rs
@@ -37,8 +37,9 @@ pub(crate) fn worker_thread_func(rx: Receiver<OperationWithCallback>) {
     let mut n_ops_received_from_user: u32 = 0;
 
     // These are the `squeue::Entry`s generated within this thread.
-    // Each inner `Vec<Entry>` will be submitted in one go. Each chain of linked entries
-    // must be in its own inner `Vec<Entry>`.
+    // Each inner `Vec<Box<Entry>>` will be submitted in one go. Each chain of linked entries
+    // must be in its own inner `Vec<Box<Entry>>`. Yes, it _should_ not be necessary to `Box` entries in
+    // a `Vec`. But it reduces page-faults from 15 K/s to 5 K/s, and increase bandwidth from 1 GiB/s to 1.3 GiB/s.
     let mut internal_op_queue: VecDeque<Vec<Box<squeue::Entry>>> =
         VecDeque::with_capacity(SQ_RING_SIZE);
 

--- a/src/io_uring_local.rs
+++ b/src/io_uring_local.rs
@@ -7,101 +7,105 @@ use io_uring::IoUring;
 use nix::sys::stat::stat;
 use nix::NixPath;
 use std::collections::VecDeque;
-use std::os::fd::RawFd;
 use std::sync::mpsc::TryRecvError;
 use std::sync::mpsc::{Receiver, RecvError};
 
 use crate::{operation::Operation, operation::OperationWithCallback, tracker::Tracker};
 
 pub(crate) fn worker_thread_func(rx: Receiver<OperationWithCallback>) {
-    const MAX_FILES_IN_FLIGHT: usize = 14;
-    const N_FILES_TO_REGISTER: usize = 16;
-    assert!(N_FILES_TO_REGISTER >= MAX_FILES_IN_FLIGHT);
+    const MAX_FILES_TO_REGISTER: usize = 14;
     const MAX_ENTRIES_PER_CHAIN: usize = 3; // Maximum number of io_uring entries per io_uring chain.
-    const SQ_RING_SIZE: usize = MAX_FILES_IN_FLIGHT * MAX_ENTRIES_PER_CHAIN; // TODO: Allow the user to configure SQ_RING_SIZE.
+    const SQ_RING_SIZE: usize = MAX_FILES_TO_REGISTER * MAX_ENTRIES_PER_CHAIN; // TODO: Allow the user to configure SQ_RING_SIZE.
     assert!(MAX_ENTRIES_PER_CHAIN < SQ_RING_SIZE);
-    const MAX_ENTRIES_BEFORE_BREAKING_LOOP: usize = SQ_RING_SIZE - MAX_ENTRIES_PER_CHAIN;
     let mut ring: IoUring<squeue::Entry, cqueue::Entry> = io_uring::IoUring::builder()
         .setup_sqpoll(1000) // The kernel sqpoll thread will sleep after this many milliseconds.
         // TODO: Allow the user to decide whether sqpoll is used.
         .build(SQ_RING_SIZE as _)
         .expect("Failed to initialise io_uring.");
 
-    // Register "fixed" file descriptors, for use in chaining open, read, close:
-    // TODO: Only register enough FDs for the files in flight in io_uring. We should re-use SQ_RING_SIZE FDs! See issue #54.
-    let _ = ring.submitter().unregister_files(); // Cleanup all fixed files (if any)
+    ring.submit().unwrap();
+    let _ = ring.submitter().unregister_files();
+    ring.submit().unwrap();
+    // Register "fixed" file descriptors, for use in chaining SQ entries:
     ring.submitter()
-        .register_files_sparse(N_FILES_TO_REGISTER as _) // TODO: Only register enough direct FDs for the ops in flight!
+        .register_files_sparse(16)
         .expect("Failed to register files!");
+    ring.submit().unwrap();
+
     // io_uring supports a max of 16 registered ring descriptors. See:
     // https://manpages.debian.org/unstable/liburing-dev/io_uring_register.2.en.html#IORING_REGISTER_RING_FDS
-    let mut next_file_descriptor: VecDeque<u32> = (0..MAX_FILES_IN_FLIGHT as u32).collect();
-    let mut fds_to_unregister = Vec::new();
 
     // Counters
-    let mut n_tasks_in_flight_in_io_uring: usize = 0;
+    let mut n_sqes_in_flight_in_io_uring: usize = 0;
+    let mut n_user_tasks_completed: u32 = 0;
+    let mut n_files_registered: usize = 0;
     let mut n_ops_received_from_user: u32 = 0;
-    let mut n_user_ops_completed: u32 = 0;
-    let mut rx_might_have_more_data_waiting: bool;
 
-    // Track ops in flight
-    let mut op_tracker = Tracker::new(SQ_RING_SIZE);
+    // These are the `squeue::Entry`s generated within this thread.
+    let mut internal_op_queue: VecDeque<squeue::Entry> = VecDeque::with_capacity(SQ_RING_SIZE);
+
+    // These are the tasks that the user submits via `rx`.
+    let mut user_tasks_in_flight = Tracker::new(SQ_RING_SIZE);
 
     'outer: loop {
-        // Keep io_uring's submission queue topped up:
+        // Keep io_uring's submission queue topped up from this thread's internal queue.
+        // The internal queue always takes precedence over tasks from the user.
         // TODO: Extract this inner loop into a separate function!
-        'inner: loop {
-            let (mut op_with_callback, fd) = match (
-                n_tasks_in_flight_in_io_uring,
-                next_file_descriptor.pop_front(),
-            ) {
-                (0, Some(fd)) => match rx.recv() {
-                    // There are no tasks in flight in io_uring, so all that's
-                    // left to do is to wait for more `Operations` from the user.
-                    Ok(s) => (s, fd),
-                    Err(RecvError) => break 'outer, // The caller hung up.
-                },
-                (MAX_ENTRIES_BEFORE_BREAKING_LOOP.., _) => {
-                    // The SQ is full!
-                    rx_might_have_more_data_waiting = true;
-                    break 'inner;
+        'inner: while n_sqes_in_flight_in_io_uring < SQ_RING_SIZE {
+            match internal_op_queue.pop_front() {
+                None => break 'inner,
+                Some(entry) => {
+
+                    unsafe {
+                        ring.submission().push(&entry).unwrap_or_else(|err| {
+                            panic!("submission queue is full {err} {n_sqes_in_flight_in_io_uring}")
+                        });
+                    }
+                    n_sqes_in_flight_in_io_uring += 1;
                 }
-                (_, Some(fd)) => match rx.try_recv() {
-                    Ok(s) => (s, fd),
+            }
+        }
+
+        // Keep io_uring's submission queue topped up with tasks from the user:
+        // TODO: Extract this inner loop into a separate function!
+        'inner: while n_files_registered < MAX_FILES_TO_REGISTER
+            && n_sqes_in_flight_in_io_uring < (SQ_RING_SIZE - MAX_ENTRIES_PER_CHAIN)
+        {
+            let mut op_with_callback = if n_sqes_in_flight_in_io_uring == 0 {
+                // There are no tasks in flight in io_uring, so all that's
+                // left to do is to wait for more `Operations` from the user.
+                match rx.recv() {
+                    Ok(s) => s,
+                    Err(RecvError) => break 'outer, // The caller hung up.
+                }
+            } else {
+                match rx.try_recv() {
+                    Ok(s) => s,
                     Err(TryRecvError::Empty) => {
-                        rx_might_have_more_data_waiting = false;
                         break 'inner;
                     }
                     Err(TryRecvError::Disconnected) => break 'outer,
-                },
-                (_, None) => {
-                    // We can't handle any more files right now!
-                    rx_might_have_more_data_waiting = true;
-                    break 'inner;
                 }
             };
 
-            let index_of_op = op_tracker.get_next_index().unwrap();
-            println!("Using {fd}");
-            op_with_callback.fd = Some(fd);
-
             // Convert `Operation` to one or more `squeue::Entry`, and submit to io_uring.
+            let index_of_op = user_tasks_in_flight.get_next_index().unwrap();
             let entries = create_sq_entries_for_op(&mut op_with_callback, index_of_op);
-            op_tracker.put(index_of_op, op_with_callback);
+            user_tasks_in_flight.put(index_of_op, op_with_callback);
             for entry in entries {
                 unsafe {
                     ring.submission().push(&entry).unwrap_or_else(|err| {
-                        panic!("submission queue is full {err} {n_tasks_in_flight_in_io_uring}")
+                        panic!("submission queue is full {err} {n_sqes_in_flight_in_io_uring}")
                     });
                 }
-                n_tasks_in_flight_in_io_uring += 1;
+                n_sqes_in_flight_in_io_uring += 1;
             }
-
-            // Increment counter:
             n_ops_received_from_user += 1;
+            n_files_registered += 1; // TODO: When we support more `Operations` than just `get`,
+                                     // we'll need a way to only increment this when appropriate.
         }
 
-        assert_ne!(n_tasks_in_flight_in_io_uring, 0);
+        assert_ne!(n_sqes_in_flight_in_io_uring, 0);
 
         if ring.completion().is_empty() {
             ring.submit_and_wait(1).unwrap();
@@ -110,71 +114,58 @@ pub(crate) fn worker_thread_func(rx: Receiver<OperationWithCallback>) {
             ring.submit().unwrap();
         }
 
-        for (i, cqe) in ring.completion().enumerate() {
-            n_tasks_in_flight_in_io_uring -= 1;
+        for cqe in ring.completion() {
+            n_sqes_in_flight_in_io_uring -= 1;
 
             // user_data holds the io_uring opcode in the lower 32 bits,
             // and holds the index_of_op in the upper 32 bits.
-            let user_data = cqe.user_data();
-            let uring_opcode = (user_data & 0xFFFFFFFF) as u8;
-            let index_of_op = (user_data >> 32) as usize;
+            let uring_opcode = (cqe.user_data() & 0xFFFFFFFF) as u8;
+            let index_of_op = (cqe.user_data() >> 32) as usize;
 
             // Handle errors reported by io_uring:
             if cqe.result() < 0 {
                 let err = nix::Error::from_i32(-cqe.result());
                 println!(
-                    "Error from CQE: {err:?}. opcode={uring_opcode}; index_of_op={index_of_op}; fd={:?}",
-                    op_tracker.as_ref(index_of_op).unwrap().fd,
+                    "Error from CQE: {err:?}. opcode={uring_opcode}; index_of_op={index_of_op}; fd=TODO",
+        
+                    //user_tasks_in_flight.as_ref(index_of_op).unwrap().fixed_fd,
                 );
                 // TODO: This error needs to be sent to the user and, ideally, associated with a filename.
                 // Something like: `Err(err.into())`. See issue #45.
             }
 
             match uring_opcode {
-                opcode::OpenAt::CODE => (), // Ignore OpenAt for now.
-                opcode::Read::CODE => {
-                    //let op_with_callback = op_tracker.as_mut(index_of_op).unwrap();
-                    //op_with_callback.execute_callback();
+                opcode::OpenAt::CODE => {
+                    let op_with_callback = user_tasks_in_flight.as_mut(index_of_op).unwrap();
+                    //dbg!(cqe.result());
+                    op_with_callback.fixed_fd = Some(types::Fixed(cqe.result() as u32));
+                    let entries =
+                        create_sq_entries_for_read_and_close(op_with_callback, index_of_op);
+                    for entry in entries {
+                        internal_op_queue.push_back(entry);
+                    }
                 }
+                opcode::Read::CODE => {}
                 opcode::Close::CODE => {
-                    let mut op_with_callback = op_tracker.remove(index_of_op).unwrap();
-                    let fd = op_with_callback.fd.unwrap();
-                    next_file_descriptor.push_back(fd);
-                    fds_to_unregister.push(fd);
+                    let mut op_with_callback = user_tasks_in_flight.remove(index_of_op).unwrap();
                     op_with_callback.execute_callback();
-                    n_user_ops_completed += 1;
+                    n_user_tasks_completed += 1;
+                }
+                opcode::FilesUpdate::CODE => {
+                    // TODO: Use FilesUpdate!
+                    n_files_registered -= 1;
                 }
                 _ => panic!("Unrecognised opcode!"),
             };
-
-            // if rx_might_have_more_data_waiting && i > (SQ_RING_SIZE / 2) as _ {
-            //     // Break, to keep the SQ topped up.
-            //     break;
-            // }
         }
-
-        if !fds_to_unregister.is_empty() {
-            let mut file_descriptors_to_update = [SKIP_FILE; N_FILES_TO_REGISTER];
-            for fd in &fds_to_unregister {
-                println!("Unregistering {}", *fd);
-                file_descriptors_to_update[*fd as usize] = -1;
-            }
-            let n_updates = ring
-                .submitter()
-                .register_files_update(0, &file_descriptors_to_update)
-                .unwrap();
-            assert_eq!(n_updates, N_FILES_TO_REGISTER);
-        }
-        ring.submission().sync();
-        fds_to_unregister.clear();
     }
-    assert_eq!(n_ops_received_from_user, n_user_ops_completed);
+    assert_eq!(n_ops_received_from_user, n_user_tasks_completed);
 }
 
 fn create_sq_entries_for_op(
     op_with_callback: &mut OperationWithCallback,
     index_of_op: usize,
-) -> [squeue::Entry; 3] {
+) -> Vec<squeue::Entry> {
     let op = op_with_callback.get_mut_operation().as_ref().unwrap();
     match op {
         Operation::Get { .. } => create_sq_entry_for_get_op(op_with_callback, index_of_op),
@@ -189,33 +180,17 @@ where
 }
 
 fn create_sq_entry_for_get_op(
-    op_with_callback: &mut OperationWithCallback,
+    op_with_callback: &OperationWithCallback,
     index_of_op: usize,
-) -> [squeue::Entry; 3] {
+) -> Vec<squeue::Entry> {
     // TODO: Test for these:
     // - opcode::OpenAt2::CODE
     // - opcode::Close::CODE
     // - opcode::Socket::CODE // to ensure fixed table support
 
-    let fixed_fd = op_with_callback.fd.unwrap();
-    let (path, buffer) = match op_with_callback.get_mut_operation().as_mut().unwrap() {
-        Operation::Get {
-            path: location,
-            buffer,
-            ..
-        } => (location, buffer),
+    let path = match op_with_callback.get_operation().as_ref().unwrap() {
+        Operation::Get { path: location, .. } => location,
     };
-
-    // See this comment for more information on chaining open, read, close in io_uring:
-    // https://github.com/JackKelly/light-speed-io/issues/1#issuecomment-1939244204
-
-    // Get filesize: TODO: Use io_uring to get filesize; see issue #41.
-    let filesize_bytes = get_filesize_bytes(path.as_c_str());
-
-    // Allocate vector:
-    // TODO: Don't initialise to all-zeros. Issue #46.
-    // See https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#initializing-an-array-element-by-element
-    let mut buf = Vec::with_capacity(filesize_bytes as _);
 
     // Convert the index_of_op into a u64, and bit-shift it left.
     // We do this so the u64 io_uring user_data represents the index_of_op in the left-most 32 bits,
@@ -226,8 +201,7 @@ fn create_sq_entry_for_get_op(
     // This code block is adapted from:
     // https://github.com/tokio-rs/io-uring/blob/e3fa23ad338af1d051ac82e18688453a9b3d8376/io-uring-test/src/tests/fs.rs#L288-L295
     let path_ptr = path.as_ptr();
-    let file_index = types::DestinationSlot::try_from_slot_target(fixed_fd)
-        .expect("Could not allocate target slot. fixed_fd={fixed_fd}");
+    let file_index = types::DestinationSlot::auto_target();
     let open_op = opcode::OpenAt::new(
         types::Fd(-1), // dirfd is ignored if the pathname is absolute. See the "openat()" section in https://man7.org/linux/man-pages/man2/openat.2.html
         path_ptr,
@@ -235,18 +209,42 @@ fn create_sq_entry_for_get_op(
     .file_index(Some(file_index))
     .flags(libc::O_RDONLY) // | libc::O_DIRECT) // TODO: Re-enable O_DIRECT.
     .build()
-    .flags(squeue::Flags::IO_LINK)
     .user_data(index_of_op | (opcode::OpenAt::CODE as u64));
 
+    vec![open_op]
+}
+
+fn create_sq_entries_for_read_and_close(
+    op_with_callback: &mut OperationWithCallback,
+    index_of_op: usize,
+) -> Vec<squeue::Entry> {
+    let fixed_fd = op_with_callback.fixed_fd.unwrap();
+    let (path, buffer) = match op_with_callback.get_mut_operation().as_mut().unwrap() {
+        Operation::Get {
+            path: location,
+            buffer,
+            ..
+        } => (location, buffer),
+    };
+
+    // Convert the index_of_op into a u64, and bit-shift it left.
+    // We do this so the u64 io_uring user_data represents the index_of_op in the left-most 32 bits,
+    // and represents the io_uring opcode CODE in the right-most 32 bits.
+    let index_of_op: u64 = (index_of_op as u64) << 32;
+
+    // Get filesize: TODO: Use io_uring to get filesize; see issue #41.
+    let filesize_bytes = get_filesize_bytes(path.as_c_str());
+
+    // Allocate vector:
+    // TODO: Don't initialise to all-zeros. Issue #46.
+    // See https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#initializing-an-array-element-by-element
+    let mut buf = Vec::with_capacity(filesize_bytes as _);
+
     // Prepare the "read" opcode:
-    let read_op = opcode::Read::new(
-        types::Fixed(fixed_fd),
-        buf.as_mut_ptr(),
-        filesize_bytes as _,
-    )
-    .build()
-    .flags(squeue::Flags::IO_LINK)
-    .user_data(index_of_op | (opcode::Read::CODE as u64));
+    let read_op = opcode::Read::new(fixed_fd, buf.as_mut_ptr(), filesize_bytes as u32)
+        .build()
+        .flags(squeue::Flags::IO_LINK)
+        .user_data(index_of_op | (opcode::Read::CODE as u64));
 
     unsafe {
         buf.set_len(filesize_bytes as _);
@@ -254,9 +252,9 @@ fn create_sq_entry_for_get_op(
     let _ = *buffer.insert(Ok(buf));
 
     // Prepare the "close" opcode:
-    let close_op = opcode::Close::new(types::Fixed(fixed_fd))
+    let close_op = opcode::Close::new(fixed_fd)
         .build()
         .user_data(index_of_op | (opcode::Close::CODE as u64));
 
-    [open_op, read_op, close_op]
+    vec![read_op, close_op]
 }

--- a/src/io_uring_local.rs
+++ b/src/io_uring_local.rs
@@ -59,7 +59,7 @@ pub(crate) fn worker_thread_func(rx: Receiver<OperationWithCallback>) {
                     }
 
                     // Unbox the entries.
-                    let entries: [squeue::Entry; 2] = [*entries[0].clone(), *entries[1].clone()];
+                    let entries = [*entries[0].clone(), *entries[1].clone()];
 
                     unsafe {
                         ring.submission()

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1,12 +1,13 @@
 use std::ffi::CString;
 
+use io_uring::types;
 use object_store::Result;
 
 pub struct OperationWithCallback {
     // This is a `Option` so we can `take` it.
     operation: Option<Operation>,
 
-    pub fd: Option<u32>,
+    pub fixed_fd: Option<types::Fixed>,
 
     // The callback function will be called when the operation completes.
     // The callback function can be an empty closure.
@@ -21,7 +22,7 @@ impl OperationWithCallback {
     {
         Self {
             operation: Some(operation),
-            fd: None,
+            fixed_fd: None,
             callback: Some(Box::new(callback)),
         }
     }
@@ -29,6 +30,10 @@ impl OperationWithCallback {
     pub(crate) fn execute_callback(&mut self) {
         let callback = self.callback.take().unwrap();
         callback(self.operation.take().unwrap());
+    }
+
+    pub(crate) fn get_operation(&self) -> &Option<Operation> {
+        &self.operation
     }
 
     pub(crate) fn get_mut_operation(&mut self) -> &mut Option<Operation> {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -6,6 +6,8 @@ pub struct OperationWithCallback {
     // This is a `Option` so we can `take` it.
     operation: Option<Operation>,
 
+    pub fd: Option<u32>,
+
     // The callback function will be called when the operation completes.
     // The callback function can be an empty closure.
     // This is an `Option` so we can `take` it.
@@ -19,6 +21,7 @@ impl OperationWithCallback {
     {
         Self {
             operation: Some(operation),
+            fd: None,
             callback: Some(Box::new(callback)),
         }
     }

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -28,6 +28,14 @@ impl<T> Tracker<T> {
         self.ops_in_flight[index].replace(op);
     }
 
+    pub(crate) fn as_mut(&mut self, index: usize) -> Option<&mut T> {
+        self.ops_in_flight[index].as_mut().map(|t| t.as_mut())
+    }
+
+    pub(crate) fn as_ref(&self, index: usize) -> Option<&T> {
+        self.ops_in_flight[index].as_ref().map(|t| t.as_ref())
+    }
+
     pub(crate) fn remove(&mut self, index: usize) -> Option<T> {
         self.ops_in_flight[index].take().map(|t| {
             self.next_index.push_back(index);


### PR DESCRIPTION
This is a follow-on PR from PR #65.

Closes:
- #62

Related:
- #41 
- #61 
- #66 

## Rough plan

- [x] Call `ring.submitter().register_files_sparse(16)` at the start of the thread.
- [x] Keep a count of the total number of files in flight, and limit the total number of files to 16. 
- [x] But don't keep track of FDs.
- [x] Each thread needs an internal queue of operations to submit to io_uring. That queue will always take precedence over operations from the outside world.
- [x] Assuming we can handle more files... Submit an `open` operation to io_uring, asking for an automatic fixed file descriptor.
- [x] After submitting `open` ops to io_uring, allocate vectors (so the allocation can happen in parallel to the `open` ops).
- [x] When each `open` CQE arrives, push linked `<read><close>` ops to the thread's internal queue.
- ~~Also submit `<release file descriptor>` op to thread's internal queue.~~ UPDATE: It appears that `closing` the file is sufficient!