### PR TITLE
Don't restrict OperationWithChannel to always using Vec<u8>

### DIFF
--- a/src/object_store_adapter.rs
+++ b/src/object_store_adapter.rs
@@ -12,7 +12,7 @@ use std::thread;
 use url::Url;
 
 use crate::io_uring_local;
-use crate::operation::{Operation, OperationWithChannel, Output};
+use crate::operation::{Operation, OperationWithOutput, Output};
 
 /// A specialized `Error` for filesystem object store-related errors
 /// From `object_store::local`
@@ -106,17 +106,17 @@ impl Config {
 #[derive(Debug)]
 struct WorkerThread {
     handle: thread::JoinHandle<()>,
-    sender: mpsc::Sender<OperationWithChannel>, // Channel to send ops to the worker thread
+    sender: mpsc::Sender<OperationWithOutput>, // Channel to send ops to the worker thread
 }
 
 impl WorkerThread {
-    pub fn new(worker_thread_func: fn(mpsc::Receiver<OperationWithChannel>)) -> Self {
+    pub fn new(worker_thread_func: fn(mpsc::Receiver<OperationWithOutput>)) -> Self {
         let (sender, rx) = mpsc::channel();
         let handle = thread::spawn(move || worker_thread_func(rx));
         Self { handle, sender }
     }
 
-    pub fn send(&self, op_with_chan: OperationWithChannel) {
+    pub fn send(&self, op_with_chan: OperationWithOutput) {
         self.sender
             .send(op_with_chan)
             .expect("Failed to send message to worker thread!");
@@ -137,7 +137,7 @@ impl Default for ObjectStoreAdapter {
 
 impl ObjectStoreAdapter {
     /// Create new filesystem storage with no prefix
-    pub fn new(func_for_get_thread: fn(mpsc::Receiver<OperationWithChannel>)) -> Self {
+    pub fn new(func_for_get_thread: fn(mpsc::Receiver<OperationWithOutput>)) -> Self {
         Self {
             config: Arc::new(Config {
                 root: Url::parse("file:///").unwrap(),
@@ -167,7 +167,7 @@ impl ObjectStoreAdapter {
             fixed_fd: None,
         };
 
-        let (op_with_chan, rx) = OperationWithChannel::new(operation);
+        let (op_with_chan, rx) = OperationWithOutput::new(operation);
 
         self.worker_thread.send(op_with_chan);
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -34,7 +34,7 @@ impl Operation {
 }
 
 #[derive(Debug)]
-pub(crate) struct OperationWithChannel {
+pub(crate) struct OperationWithOutput {
     operation: Operation,
     output: Option<Output>,
     // `output_channel` is an `Option` because `send` consumes itself,
@@ -43,7 +43,7 @@ pub(crate) struct OperationWithChannel {
     error_has_occurred: bool,
 }
 
-impl OperationWithChannel {
+impl OperationWithOutput {
     pub(crate) fn new(operation: Operation) -> (Self, oneshot::Receiver<anyhow::Result<Output>>) {
         let (output_channel, rx) = oneshot::channel();
         (

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -16,29 +16,40 @@ pub(crate) enum Operation {
         // We need to ensure the CString is valid until the completion queue entry arrives.
         // So we keep the CString here, in the `Operation`.
         path: CString,
-
-        // This is an `Option` for two reasons: 1) `buffer` will start life
-        // _without_ an actual buffer! 2) So we can `take` the buffer.
-        buffer: Option<anyhow::Result<Vec<u8>>>,
         fixed_fd: Option<types::Fixed>,
     },
 }
 
 #[derive(Debug)]
+pub(crate) enum Output {
+    Get { buffer: Vec<u8> },
+}
+
+impl Operation {
+    fn matches(&self, output: &Output) -> bool {
+        match self {
+            Operation::Get { .. } => matches!(output, Output::Get { .. }),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub(crate) struct OperationWithChannel {
-    pub(crate) operation: Operation,
+    operation: Operation,
+    output: Option<Output>,
     // `output_channel` is an `Option` because `send` consumes itself,
     // so we need to `output_channel.take().unwrap().send(Some(buffer))`.
-    output_channel: Option<oneshot::Sender<anyhow::Result<Vec<u8>>>>,
+    output_channel: Option<oneshot::Sender<anyhow::Result<Output>>>,
     error_has_occurred: bool,
 }
 
 impl OperationWithChannel {
-    pub(crate) fn new(operation: Operation) -> (Self, oneshot::Receiver<anyhow::Result<Vec<u8>>>) {
+    pub(crate) fn new(operation: Operation) -> (Self, oneshot::Receiver<anyhow::Result<Output>>) {
         let (output_channel, rx) = oneshot::channel();
         (
             Self {
                 operation,
+                output: None,
                 output_channel: Some(output_channel),
                 error_has_occurred: false,
             },
@@ -46,16 +57,26 @@ impl OperationWithChannel {
         )
     }
 
-    pub(crate) fn send_result(&mut self) {
-        match self.operation {
-            Operation::Get { ref mut buffer, .. } => {
-                self.output_channel
-                    .take()
-                    .unwrap()
-                    .send(buffer.take().unwrap())
-                    .unwrap();
-            }
-        }
+    pub(crate) fn operation(&self) -> &Operation {
+        &self.operation
+    }
+
+    pub(crate) fn operation_mut(&mut self) -> &mut Operation {
+        &mut self.operation
+    }
+
+    pub(crate) fn set_output(&mut self, output: Output) {
+        // Sanity check that the output is the correct variant:
+        assert!(&self.operation.matches(&output));
+        self.output = Some(output);
+    }
+
+    pub(crate) fn send_output(&mut self) {
+        self.output_channel
+            .take()
+            .unwrap()
+            .send(Ok(self.output.take().unwrap()))
+            .unwrap();
     }
 
     pub(crate) fn error_has_occurred(&self) -> bool {


### PR DESCRIPTION
`Operation` and `Output` are now two distinct enums.